### PR TITLE
Update .gitignore to include additional archive formats: .rar, .7z, .…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *.zip
+*.rar
+*.7z
+*.tar
+*.gz
+*.bz2
+*.deb
+*.rpm


### PR DESCRIPTION
…tar, .gz, .bz2, .deb, and .rpm.